### PR TITLE
Publications

### DIFF
--- a/mobilizon_bots/event/event.py
+++ b/mobilizon_bots/event/event.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass, asdict
-from enum import IntEnum
 from typing import Optional
 
 import arrow
@@ -8,13 +7,6 @@ from jinja2 import Template
 
 from mobilizon_bots.models.event import Event
 from mobilizon_bots.models.publication import PublicationStatus
-
-
-class NotificationStatus(IntEnum):
-    WAITING = 1
-    FAILED = 2
-    PARTIAL = 3
-    COMPLETED = 4
 
 
 @dataclass

--- a/mobilizon_bots/event/event.py
+++ b/mobilizon_bots/event/event.py
@@ -3,17 +3,11 @@ from enum import IntEnum
 from typing import Optional
 
 import arrow
-from jinja2 import Template
 import tortoise.timezone
+from jinja2 import Template
 
 from mobilizon_bots.models.event import Event
-
-
-class PublicationStatus(IntEnum):
-    WAITING = 1
-    FAILED = 2
-    PARTIAL = 3
-    COMPLETED = 4
+from mobilizon_bots.models.publication import PublicationStatus
 
 
 class NotificationStatus(IntEnum):

--- a/mobilizon_bots/event/event_selector.py
+++ b/mobilizon_bots/event/event_selector.py
@@ -11,6 +11,7 @@ class EventSelectionStrategy(ABC):
         self,
         published_events: List[MobilizonEvent],
         unpublished_events: List[MobilizonEvent],
+        publisher_name: str,
     ) -> Optional[MobilizonEvent]:
         pass
 
@@ -25,18 +26,19 @@ class SelectNextEventStrategy(EventSelectionStrategy):
         self,
         published_events: List[MobilizonEvent],
         unpublished_events: List[MobilizonEvent],
+        publisher_name: str = "telegram",
     ) -> Optional[MobilizonEvent]:
 
         last_published_event = published_events[-1]
         first_unpublished_event = unpublished_events[0]
         now = arrow.now()
-        assert last_published_event.publication_time < now, (
+        assert last_published_event.publication_time[publisher_name] < now, (
             f"Last published event has been published in the future\n"
-            f"{last_published_event.publication_time}\n"
+            f"{last_published_event.publication_time[publisher_name]}\n"
             f"{now}"
         )
         if (
-            last_published_event.publication_time.shift(
+            last_published_event.publication_time[publisher_name].shift(
                 minutes=self.minimum_break_between_events_in_minutes
             )
             > now

--- a/mobilizon_bots/main.py
+++ b/mobilizon_bots/main.py
@@ -4,9 +4,15 @@ from pathlib import Path
 from tortoise import run_async
 
 from mobilizon_bots.config.config import settings
+
+from mobilizon_bots.config.publishers import get_active_publishers
+from mobilizon_bots.event.event_selector import EventSelector, SelectNextEventStrategy
 from mobilizon_bots.mobilizon.events import get_unpublished_events
 from mobilizon_bots.storage.db import MobilizonBotsDB
-from mobilizon_bots.storage.query import get_published_events
+from mobilizon_bots.storage.query import get_published_events, create_unpublished_events
+from mobilizon_bots.storage.query import (
+    get_unpublished_events as get_db_unpublished_events,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -17,11 +23,27 @@ async def main():
     :return:
     """
     logging.config.dictConfig(settings.logging)
+    active_publishers = get_active_publishers(settings)
+
     db = MobilizonBotsDB(Path(settings.db_path))
     await db.setup()
-    published_events = await get_published_events()
+
+    # Load past events
+    published_events = list(await get_published_events())
+
+    # Pull unpublished events from Mobilizon
     unpublished_events = get_unpublished_events(published_events)
-    event = select_event_to_publish()
+    # Store in the DB only the ones we din't know about
+    await create_unpublished_events(unpublished_events, active_publishers)
+    unpublished_events = list(await get_db_unpublished_events())
+
+    event_selector = EventSelector(
+        unpublished_events=unpublished_events, published_events=published_events
+    )
+    # TODO: Here we should somehow handle publishers
+    strategy = SelectNextEventStrategy(minimum_break_between_events_in_minutes=360)
+    event = event_selector.select_event_to_publish(strategy)
+
     result = PublisherCoordinator(event).publish() if event else exit(0)
     exit(0 if result.is_success() else 1)
 

--- a/mobilizon_bots/models/event.py
+++ b/mobilizon_bots/models/event.py
@@ -16,6 +16,8 @@ class Event(Model):
     begin_datetime = fields.DatetimeField()
     end_datetime = fields.DatetimeField()
 
+    publications: fields.ReverseRelation["Publication"]
+
     def __str__(self):
         return self.name
 

--- a/mobilizon_bots/models/notification.py
+++ b/mobilizon_bots/models/notification.py
@@ -1,7 +1,14 @@
+from enum import IntEnum
+
 from tortoise import fields
 from tortoise.models import Model
 
-from mobilizon_bots.event.event import NotificationStatus
+
+class NotificationStatus(IntEnum):
+    WAITING = 1
+    FAILED = 2
+    PARTIAL = 3
+    COMPLETED = 4
 
 
 class Notification(Model):

--- a/mobilizon_bots/models/publication.py
+++ b/mobilizon_bots/models/publication.py
@@ -1,14 +1,23 @@
+from enum import IntEnum
+
 from tortoise import fields
 from tortoise.models import Model
 
-from mobilizon_bots.event.event import PublicationStatus
+
+class PublicationStatus(IntEnum):
+    WAITING = 1
+    FAILED = 2
+    PARTIAL = 3
+    COMPLETED = 4
 
 
 class Publication(Model):
     id = fields.UUIDField(pk=True)
     status = fields.IntEnumField(PublicationStatus)
 
-    timestamp = fields.DatetimeField()
+    # When a Publication's status is WAITING
+    # we don't need a timestamp
+    timestamp = fields.DatetimeField(null=True)
 
     event = fields.ForeignKeyField("models.Event", related_name="publications")
     publisher = fields.ForeignKeyField("models.Publisher", related_name="publications")

--- a/mobilizon_bots/models/publisher.py
+++ b/mobilizon_bots/models/publisher.py
@@ -4,8 +4,11 @@ from tortoise.models import Model
 
 class Publisher(Model):
     id = fields.UUIDField(pk=True)
-    type = fields.CharField(max_length=255)
-    account_ref = fields.CharField(max_length=512)
+    name = fields.CharField(max_length=256)
+    # TODO: What to do with this?
+    account_ref = fields.TextField(null=True)
+
+    publications: fields.ReverseRelation["Publication"]
 
     def __str__(self):
         return f"{self.id}"

--- a/mobilizon_bots/storage/db.py
+++ b/mobilizon_bots/storage/db.py
@@ -6,6 +6,9 @@ from pathlib import Path
 
 from tortoise import Tortoise
 
+from mobilizon_bots.config.publishers import publisher_names
+from mobilizon_bots.storage.query import create_publisher
+
 logger = logging.getLogger(__name__)
 
 
@@ -18,7 +21,6 @@ class MobilizonBotsDB:
             self.path.parent.mkdir(parents=True, exist_ok=True)
 
     async def setup(self):
-        # TODO: Caricare i publishers.
         await Tortoise.init(
             db_url=f"sqlite:///{self.path}",
             modules={
@@ -34,6 +36,10 @@ class MobilizonBotsDB:
         )
         if not self.is_init:
             await Tortoise.generate_schemas()
+            for name in publisher_names:
+                logging.info(f"Creating {name} publisher")
+                # TODO: Deal with account_ref
+                await create_publisher(name)
             self.is_init = True
             logger.info(f"Succesfully initialized database at {self.path}")
 

--- a/mobilizon_bots/storage/query.py
+++ b/mobilizon_bots/storage/query.py
@@ -6,19 +6,25 @@ from mobilizon_bots.models.publication import PublicationStatus
 from mobilizon_bots.models.publisher import Publisher
 
 
-async def get_published_events() -> Iterable[MobilizonEvent]:
+async def events_with_status(statuses: list[PublicationStatus]) -> Iterable[MobilizonEvent]:
     return map(
         MobilizonEvent.from_model,
         await Event.filter(
-            publications__status__in=[
-                PublicationStatus.COMPLETED,
-                PublicationStatus.PARTIAL,
-            ]
+            publications__status__in=statuses
         )
+        .prefetch_related("publications")
+        .prefetch_related("publications__publisher")
         .order_by("begin_datetime")
-        .distinct(),
+        .distinct()
     )
 
 
-async def create_publisher(name: str, account_ref: Optional[str] = None):
+async def get_published_events() -> Iterable[MobilizonEvent]:
+    return await events_with_status([
+            PublicationStatus.COMPLETED,
+            PublicationStatus.PARTIAL,
+        ])
+
+
+async def create_publisher(name: str, account_ref: Optional[str] = None) -> None:
     await Publisher.create(name=name, account_ref=account_ref)

--- a/mobilizon_bots/storage/query.py
+++ b/mobilizon_bots/storage/query.py
@@ -1,7 +1,8 @@
-from typing import Iterable
+from typing import Iterable, Optional
 
 from mobilizon_bots.event.event import MobilizonEvent, PublicationStatus
 from mobilizon_bots.models.event import Event
+from mobilizon_bots.models.publisher import Publisher
 
 
 async def get_published_events() -> Iterable[MobilizonEvent]:
@@ -16,3 +17,7 @@ async def get_published_events() -> Iterable[MobilizonEvent]:
         .order_by("begin_datetime")
         .distinct(),
     )
+
+
+async def create_publisher(name: str, account_ref: Optional[str] = None):
+    await Publisher.create(name=name, account_ref=account_ref)

--- a/mobilizon_bots/storage/query.py
+++ b/mobilizon_bots/storage/query.py
@@ -1,7 +1,8 @@
 from typing import Iterable, Optional
 
-from mobilizon_bots.event.event import MobilizonEvent, PublicationStatus
+from mobilizon_bots.event.event import MobilizonEvent
 from mobilizon_bots.models.event import Event
+from mobilizon_bots.models.publication import PublicationStatus
 from mobilizon_bots.models.publisher import Publisher
 
 

--- a/mobilizon_bots/storage/query.py
+++ b/mobilizon_bots/storage/query.py
@@ -26,5 +26,11 @@ async def get_published_events() -> Iterable[MobilizonEvent]:
         ])
 
 
+async def get_unpublished_events() -> Iterable[MobilizonEvent]:
+    return await events_with_status([
+            PublicationStatus.WAITING,
+        ])
+
+
 async def create_publisher(name: str, account_ref: Optional[str] = None) -> None:
     await Publisher.create(name=name, account_ref=account_ref)

--- a/mobilizon_bots/storage/query.py
+++ b/mobilizon_bots/storage/query.py
@@ -1,35 +1,67 @@
 from typing import Iterable, Optional
 
+from tortoise.transactions import atomic
+
 from mobilizon_bots.event.event import MobilizonEvent
 from mobilizon_bots.models.event import Event
-from mobilizon_bots.models.publication import PublicationStatus
+from mobilizon_bots.models.publication import Publication, PublicationStatus
 from mobilizon_bots.models.publisher import Publisher
 
 
-async def events_with_status(statuses: list[PublicationStatus]) -> Iterable[MobilizonEvent]:
+async def events_with_status(
+    statuses: list[PublicationStatus],
+) -> Iterable[MobilizonEvent]:
     return map(
         MobilizonEvent.from_model,
-        await Event.filter(
-            publications__status__in=statuses
-        )
+        await Event.filter(publications__status__in=statuses)
         .prefetch_related("publications")
         .prefetch_related("publications__publisher")
         .order_by("begin_datetime")
-        .distinct()
+        .distinct(),
     )
 
 
 async def get_published_events() -> Iterable[MobilizonEvent]:
-    return await events_with_status([
+    return await events_with_status(
+        [
             PublicationStatus.COMPLETED,
             PublicationStatus.PARTIAL,
-        ])
+        ]
+    )
 
 
 async def get_unpublished_events() -> Iterable[MobilizonEvent]:
-    return await events_with_status([
+    return await events_with_status(
+        [
             PublicationStatus.WAITING,
-        ])
+        ]
+    )
+
+
+@atomic("models")
+async def create_unpublished_events(
+    unpublished_events: Iterable[MobilizonEvent], active_publishers: Iterable[str]
+) -> None:
+    # We store only new events, i.e. events whose mobilizon_id wasn't found in the DB.
+    db_unpublished_events_mobilizon_ids = map(
+        lambda event: event.mobilizon_id, await get_unpublished_events()
+    )
+    absent_events = filter(
+        lambda event: event.mobilizon_id not in db_unpublished_events_mobilizon_ids,
+        unpublished_events,
+    )
+
+    for event in absent_events:
+        event_model = event.to_model()
+        await event_model.save()
+
+        for publisher_name in active_publishers:
+            publisher = await Publisher.filter(name=publisher_name).first()
+            await Publication.create(
+                status=PublicationStatus.WAITING,
+                event_id=event_model.id,
+                publisher_id=publisher.id,
+            )
 
 
 async def create_publisher(name: str, account_ref: Optional[str] = None) -> None:

--- a/mobilizon_bots/storage/query.py
+++ b/mobilizon_bots/storage/query.py
@@ -40,18 +40,19 @@ async def get_unpublished_events() -> Iterable[MobilizonEvent]:
 
 @atomic("models")
 async def create_unpublished_events(
-    unpublished_events: Iterable[MobilizonEvent], active_publishers: Iterable[str]
+    unpublished_mobilizon_events: Iterable[MobilizonEvent],
+    active_publishers: Iterable[str],
 ) -> None:
     # We store only new events, i.e. events whose mobilizon_id wasn't found in the DB.
-    db_unpublished_events_mobilizon_ids = map(
-        lambda event: event.mobilizon_id, await get_unpublished_events()
+    unpublished_event_models = set(
+        map(lambda event: event.mobilizon_id, await get_unpublished_events())
     )
-    absent_events = filter(
-        lambda event: event.mobilizon_id not in db_unpublished_events_mobilizon_ids,
-        unpublished_events,
+    unpublished_events = filter(
+        lambda event: event.mobilizon_id not in unpublished_event_models,
+        unpublished_mobilizon_events,
     )
 
-    for event in absent_events:
+    for event in unpublished_events:
         event_model = event.to_model()
         await event_model.save()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,12 +12,11 @@ from mobilizon_bots.config.config import build_and_validate_settings
 
 from mobilizon_bots.event.event import (
     MobilizonEvent,
-    PublicationStatus,
     NotificationStatus,
 )
 from mobilizon_bots.models.event import Event
 from mobilizon_bots.models.notification import Notification
-from mobilizon_bots.models.publication import Publication
+from mobilizon_bots.models.publication import Publication, PublicationStatus
 from mobilizon_bots.models.publisher import Publisher
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,9 +10,7 @@ from tortoise.contrib.test import finalizer, initializer
 
 from mobilizon_bots.config.config import build_and_validate_settings
 
-from mobilizon_bots.event.event import (
-    MobilizonEvent
-)
+from mobilizon_bots.event.event import MobilizonEvent
 from mobilizon_bots.models.event import Event
 from mobilizon_bots.models.notification import Notification, NotificationStatus
 from mobilizon_bots.models.publication import Publication, PublicationStatus
@@ -43,6 +41,7 @@ def event_generator():
         begin_date=arrow.Arrow(year=2021, month=1, day=1, hour=11, minute=30),
         published=False,
         publication_time=None,
+        mobilizon_id="12345",
     ):
 
         return MobilizonEvent(
@@ -51,7 +50,7 @@ def event_generator():
             begin_datetime=begin_date,
             end_datetime=begin_date.shift(hours=2),
             mobilizon_link="http://some_link.com/123",
-            mobilizon_id="12345",
+            mobilizon_id=mobilizon_id,
             thumbnail_link="http://some_link.com/123.jpg",
             location="location",
             publication_status=generate_publication_status(published),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,7 +136,7 @@ def publisher_model_generator():
     def _publisher_model_generator(
         idx=1,
     ):
-        return Publisher(type=f"publisher_{idx}", account_ref=f"account_ref_{idx}")
+        return Publisher(name=f"publisher_{idx}", account_ref=f"account_ref_{idx}")
 
     return _publisher_model_generator
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,11 +11,10 @@ from tortoise.contrib.test import finalizer, initializer
 from mobilizon_bots.config.config import build_and_validate_settings
 
 from mobilizon_bots.event.event import (
-    MobilizonEvent,
-    NotificationStatus,
+    MobilizonEvent
 )
 from mobilizon_bots.models.event import Event
-from mobilizon_bots.models.notification import Notification
+from mobilizon_bots.models.notification import Notification, NotificationStatus
 from mobilizon_bots.models.publication import Publication, PublicationStatus
 from mobilizon_bots.models.publisher import Publisher
 

--- a/tests/event/test_strategies.py
+++ b/tests/event/test_strategies.py
@@ -20,7 +20,9 @@ def test_window_simple_no_event(
     published_events = [
         event_generator(
             published=True,
-            publication_time=arrow.now().shift(days=-days_passed_from_publication),
+            publication_time={
+                "telegram": arrow.now().shift(days=-days_passed_from_publication)
+            },
         )
     ]
 
@@ -34,7 +36,9 @@ def test_window_simple_no_event(
     "desired_break_window_days,days_passed_from_publication", [[1, 2], [2, 10], [4, 4]]
 )
 def test_window_simple_event_found(
-    event_generator, desired_break_window_days, days_passed_from_publication,
+    event_generator,
+    desired_break_window_days,
+    days_passed_from_publication,
 ):
     "Testing that the break between events is respected and an event is found"
     unpublished_events = [
@@ -46,7 +50,9 @@ def test_window_simple_event_found(
     published_events = [
         event_generator(
             published=True,
-            publication_time=arrow.now().shift(days=-days_passed_from_publication),
+            publication_time={
+                "telegram": arrow.now().shift(days=-days_passed_from_publication)
+            },
         )
     ]
 
@@ -60,7 +66,9 @@ def test_window_simple_event_found(
     "desired_break_window_days,days_passed_from_publication", [[1, 2], [2, 10], [4, 4]]
 )
 def test_window_multi_event_found(
-    event_generator, desired_break_window_days, days_passed_from_publication,
+    event_generator,
+    desired_break_window_days,
+    days_passed_from_publication,
 ):
     "Testing that the break between events is respected when there are multiple events"
     unpublished_events = [
@@ -80,15 +88,21 @@ def test_window_multi_event_found(
     published_events = [
         event_generator(
             published=True,
-            publication_time=arrow.now().shift(days=-days_passed_from_publication),
+            publication_time={
+                "telegram": arrow.now().shift(days=-days_passed_from_publication)
+            },
         ),
         event_generator(
             published=True,
-            publication_time=arrow.now().shift(days=-days_passed_from_publication - 2),
+            publication_time={
+                "telegram": arrow.now().shift(days=-days_passed_from_publication - 2)
+            },
         ),
         event_generator(
             published=True,
-            publication_time=arrow.now().shift(days=-days_passed_from_publication - 4),
+            publication_time={
+                "telegram": arrow.now().shift(days=-days_passed_from_publication - 4)
+            },
         ),
     ]
 

--- a/tests/mobilizon/conftest.py
+++ b/tests/mobilizon/conftest.py
@@ -15,7 +15,10 @@ def mock_mobilizon_success_answer(mobilizon_answer, mobilizon_url):
     with responses.RequestsMock() as rsps:
 
         rsps.add(
-            responses.POST, mobilizon_url, json=mobilizon_answer, status=200,
+            responses.POST,
+            mobilizon_url,
+            json=mobilizon_answer,
+            status=200,
         )
         yield
 
@@ -26,6 +29,8 @@ def mock_mobilizon_failure_answer(mobilizon_url):
     with responses.RequestsMock() as rsps:
 
         rsps.add(
-            responses.POST, mobilizon_url, status=500,
+            responses.POST,
+            mobilizon_url,
+            status=500,
         )
         yield

--- a/tests/mobilizon/test_events.py
+++ b/tests/mobilizon/test_events.py
@@ -1,7 +1,7 @@
 import pytest
 import arrow
 
-from mobilizon_bots.event.event import PublicationStatus, MobilizonEvent
+from mobilizon_bots.event.event import MobilizonEvent
 from mobilizon_bots.mobilizon.events import (
     get_mobilizon_future_events,
     MobilizonRequestFailed,
@@ -57,8 +57,6 @@ simple_event = MobilizonEvent(
     mobilizon_id="1e2e5943-4a5c-497a-b65d-90457b715d7b",
     thumbnail_link=None,
     location=None,
-    publication_time=None,
-    publication_status=PublicationStatus.WAITING,
 )
 
 full_event = MobilizonEvent(
@@ -70,8 +68,6 @@ full_event = MobilizonEvent(
     mobilizon_id="56e7ca43-1b6b-4c50-8362-0439393197e6",
     thumbnail_link=None,
     location="http://some_location",
-    publication_time=None,
-    publication_status=PublicationStatus.WAITING,
 )
 
 

--- a/tests/models/test_notification.py
+++ b/tests/models/test_notification.py
@@ -1,7 +1,6 @@
 import pytest
 
-from mobilizon_bots.event.event import NotificationStatus
-from mobilizon_bots.models.notification import Notification
+from mobilizon_bots.models.notification import Notification, NotificationStatus
 
 
 @pytest.mark.asyncio

--- a/tests/models/test_publication.py
+++ b/tests/models/test_publication.py
@@ -3,8 +3,7 @@ import pytest
 from datetime import datetime
 from tortoise import timezone
 
-from mobilizon_bots.event.event import PublicationStatus
-from mobilizon_bots.models.publication import Publication
+from mobilizon_bots.models.publication import Publication, PublicationStatus
 
 
 @pytest.mark.asyncio

--- a/tests/models/test_publisher.py
+++ b/tests/models/test_publisher.py
@@ -7,5 +7,5 @@ from mobilizon_bots.models.publisher import Publisher
 async def test_publisher_create(publisher_model_generator):
     publisher_model = publisher_model_generator()
     await publisher_model.save()
-    publisher_db = await Publisher.filter(type="publisher_1").first()
+    publisher_db = await Publisher.filter(name="publisher_1").first()
     assert publisher_db.account_ref == "account_ref_1"

--- a/tests/storage/test_query.py
+++ b/tests/storage/test_query.py
@@ -125,7 +125,7 @@ async def test_create_unpublished_events(
     events_from_internet = [MobilizonEvent.from_model(events[0]), event_4, event_5]
 
     await create_unpublished_events(
-        unpublished_events=events_from_internet,
+        unpublished_mobilizon_events=events_from_internet,
         active_publishers=["publisher_1", "publisher_2"],
     )
     unpublished_events = list(await get_unpublished_events())

--- a/tests/storage/test_query.py
+++ b/tests/storage/test_query.py
@@ -8,7 +8,7 @@ from mobilizon_bots.storage.query import get_published_events
 
 
 @pytest.mark.asyncio
-async def test_get_unpublished_events(
+async def test_get_published_events(
     publisher_model_generator, publication_model_generator, event_model_generator
 ):
     today = datetime(

--- a/tests/storage/test_query.py
+++ b/tests/storage/test_query.py
@@ -4,56 +4,94 @@ import arrow
 import pytest
 
 from mobilizon_bots.event.event import PublicationStatus
-from mobilizon_bots.storage.query import get_published_events
+from mobilizon_bots.storage.query import get_published_events, get_unpublished_events
+
+
+@pytest.fixture(scope="module")
+def setup():
+    async def _setup(
+        publisher_model_generator, publication_model_generator, event_model_generator
+    ):
+        today = datetime(
+            year=2021,
+            month=6,
+            day=6,
+            hour=5,
+            minute=0,
+            tzinfo=timezone(timedelta(hours=2)),
+        )
+        publisher_1 = publisher_model_generator()
+        publisher_2 = publisher_model_generator(idx=2)
+        await publisher_1.save()
+        await publisher_2.save()
+
+        event_1 = event_model_generator(begin_date=today)
+        event_2 = event_model_generator(idx=2, begin_date=today + timedelta(days=2))
+        event_3 = event_model_generator(idx=3, begin_date=today + timedelta(days=-2))
+        await event_1.save()
+        await event_2.save()
+        await event_3.save()
+
+        publication_1 = publication_model_generator(
+            event_id=event_1.id, publisher_id=publisher_1.id
+        )
+        publication_2 = publication_model_generator(
+            event_id=event_1.id,
+            publisher_id=publisher_2.id,
+            status=PublicationStatus.COMPLETED,
+        )
+        publication_3 = publication_model_generator(
+            event_id=event_2.id,
+            publisher_id=publisher_1.id,
+            status=PublicationStatus.FAILED,
+        )
+        publication_4 = publication_model_generator(
+            event_id=event_3.id,
+            publisher_id=publisher_2.id,
+            status=PublicationStatus.PARTIAL,
+        )
+        await publication_1.save()
+        await publication_2.save()
+        await publication_3.save()
+        await publication_4.save()
+        return (
+            [event_1, event_2, event_3],
+            [publication_1, publication_2, publication_3, publication_4],
+            [publisher_1, publisher_2],
+            today,
+        )
+
+    return _setup
 
 
 @pytest.mark.asyncio
 async def test_get_published_events(
-    publisher_model_generator, publication_model_generator, event_model_generator
+    publisher_model_generator, publication_model_generator, event_model_generator, setup
 ):
-    today = datetime(
-        year=2021, month=6, day=6, hour=5, minute=0, tzinfo=timezone(timedelta(hours=2))
+    events, publications, publishers, today = await setup(
+        publisher_model_generator, publication_model_generator, event_model_generator
     )
-    publisher_1 = publisher_model_generator()
-    publisher_2 = publisher_model_generator(idx=2)
-    await publisher_1.save()
-    await publisher_2.save()
-
-    event_1 = event_model_generator(begin_date=today)
-    event_2 = event_model_generator(idx=2, begin_date=today + timedelta(days=2))
-    event_3 = event_model_generator(idx=3, begin_date=today + timedelta(days=-2))
-    await event_1.save()
-    await event_2.save()
-    await event_3.save()
-
-    publication_1 = publication_model_generator(
-        event_id=event_1.id, publisher_id=publisher_1.id
-    )
-    publication_2 = publication_model_generator(
-        event_id=event_1.id,
-        publisher_id=publisher_2.id,
-        status=PublicationStatus.COMPLETED,
-    )
-    publication_3 = publication_model_generator(
-        event_id=event_2.id,
-        publisher_id=publisher_1.id,
-        status=PublicationStatus.FAILED,
-    )
-    publication_4 = publication_model_generator(
-        event_id=event_3.id,
-        publisher_id=publisher_2.id,
-        status=PublicationStatus.PARTIAL,
-    )
-    await publication_1.save()
-    await publication_2.save()
-    await publication_3.save()
-    await publication_4.save()
 
     published_events = list(await get_published_events())
     assert len(published_events) == 2
 
-    assert published_events[0].name == event_3.name
-    assert published_events[1].name == event_1.name
+    assert published_events[0].name == events[2].name
+    assert published_events[1].name == events[0].name
 
     assert published_events[0].begin_datetime == arrow.get(today + timedelta(days=-2))
     assert published_events[1].begin_datetime == arrow.get(today)
+
+
+@pytest.mark.asyncio
+async def test_get_unpublished_events(
+    publisher_model_generator, publication_model_generator, event_model_generator, setup
+):
+    events, publications, publishers, today = await setup(
+        publisher_model_generator, publication_model_generator, event_model_generator
+    )
+
+    published_events = list(await get_unpublished_events())
+    assert len(published_events) == 1
+
+    assert published_events[0].name == events[0].name
+    assert published_events[0].begin_datetime == arrow.get(today)

--- a/tests/storage/test_query.py
+++ b/tests/storage/test_query.py
@@ -54,7 +54,7 @@ def setup():
         publication_4 = publication_model_generator(
             event_id=event_3.id,
             publisher_id=publisher_2.id,
-            status=PublicationStatus.PARTIAL,
+            status=PublicationStatus.WAITING,
         )
         await publication_1.save()
         await publication_2.save()
@@ -79,13 +79,11 @@ async def test_get_published_events(
     )
 
     published_events = list(await get_published_events())
-    assert len(published_events) == 2
+    assert len(published_events) == 1
 
-    assert published_events[0].name == events[2].name
-    assert published_events[1].name == events[0].name
+    assert published_events[0].name == events[0].name
 
-    assert published_events[0].begin_datetime == arrow.get(today + timedelta(days=-2))
-    assert published_events[1].begin_datetime == arrow.get(today)
+    assert published_events[0].begin_datetime == arrow.get(today)
 
 
 @pytest.mark.asyncio
@@ -97,10 +95,12 @@ async def test_get_unpublished_events(
     )
 
     published_events = list(await get_unpublished_events())
-    assert len(published_events) == 1
+    assert len(published_events) == 2
 
-    assert published_events[0].name == events[0].name
-    assert published_events[0].begin_datetime == arrow.get(today)
+    assert published_events[0].name == events[2].name
+    assert published_events[1].name == events[0].name
+    assert published_events[0].begin_datetime == events[2].begin_datetime
+    assert published_events[1].begin_datetime == events[0].begin_datetime
 
 
 @pytest.mark.asyncio
@@ -130,7 +130,8 @@ async def test_create_unpublished_events(
     )
     unpublished_events = list(await get_unpublished_events())
 
-    assert len(unpublished_events) == 3
-    assert unpublished_events[0].mobilizon_id == events[0].mobilizon_id
-    assert unpublished_events[1].mobilizon_id == "12345"
-    assert unpublished_events[2].mobilizon_id == "67890"
+    assert len(unpublished_events) == 4
+    assert unpublished_events[0].mobilizon_id == "mobid_3"
+    assert unpublished_events[1].mobilizon_id == "mobid_1"
+    assert unpublished_events[2].mobilizon_id == "12345"
+    assert unpublished_events[3].mobilizon_id == "67890"


### PR DESCRIPTION
This PR changes the public interface of `MobilizonEvent` to
support multiple publications. This mainly entails two changes:

  - When instancing a `MobilizonEvent`  from an `Event` model
    the `publication_status` will be computed by looking at
    the statuses of all the related publications.
  - Now the `publication_time` is a `dict[str, Arrow]`. This
    enables tracking multiple social platforms publication time.